### PR TITLE
Kafkerl as OTP application

### DIFF
--- a/src/kafkerl.app.src
+++ b/src/kafkerl.app.src
@@ -3,7 +3,9 @@
 , [ {description, "Apache Kafka 0.8.2 high performance producer/consumer for erlang."}
   , {vsn, "2.1.0"}
   , {applications, [kernel, stdlib]}
+  , {mod, {kafkerl_app, []}}
   , {modules, [ kafkerl
+              , kafkerl_app
               , kafkerl_broker_connection
               , kafkerl_connector
               , kafkerl_error

--- a/src/kafkerl.erl
+++ b/src/kafkerl.erl
@@ -1,7 +1,7 @@
 -module(kafkerl).
 -author('hernanrivasacosta@gmail.com').
 
--export([start/0, start/2]).
+-export([start/0]).
 -export([produce/3, produce/4, produce/5,
          consume/2, consume/3, consume/4, stop_consuming/2, stop_consuming/3,
          request_metadata/0, request_metadata/1, request_metadata/2,
@@ -42,10 +42,6 @@
 start() ->
   ok = application:load(?MODULE),
   application:start(?MODULE).
-
--spec start(any(), any()) -> {ok, pid()}.
-start(_StartType, _StartArgs) ->
-  kafkerl_sup:start_link().
 
 %%==============================================================================
 %% Access API

--- a/src/kafkerl_app.erl
+++ b/src/kafkerl_app.erl
@@ -1,0 +1,13 @@
+-module(kafkerl_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+-spec start(any(), any()) -> {ok, pid()}.
+start(_StartType, _StartArgs) ->
+  kafkerl_sup:start_link().
+
+-spec stop(any()) -> ok.
+stop(_State) ->
+  ok.


### PR DESCRIPTION
This PR makes sure Kafkerl is a registered standard OTP application by implementing the behavior.